### PR TITLE
LazySegTree fix for custom join

### DIFF
--- a/Library/Data Structures/SegTreeLazy.cpp
+++ b/Library/Data Structures/SegTreeLazy.cpp
@@ -5,26 +5,26 @@ template<typename T> struct SegTree {
 	vector<T> seg;
 	vector<T> lazy;
 	int N;
-	T NEUTRO = 0;
-	SegTree(int n) : N(n){ seg.assign(4*N, NEUTRO), lazy.assign(4*N, NEUTRO); }
+	T IDENTITY = T();
+	SegTree(int n) : N(n){ seg.assign(4*N, IDENTITY), lazy.assign(4*N, IDENTITY); }
 	SegTree(vector<T> &lista) : N(lista.size()){ 
-		seg.assign(4*N), lazy.assign(4*N, NEUTRO); 
+		seg.assign(4*N, IDENTITY), lazy.assign(4*N, IDENTITY); 
 		build(1, 0, N-1, lista); 
 	}
 	T join(T lv, T rv){ return lv + rv; }
 	void unlazy(int no, int l, int r){
-		if(lazy[no] == NEUTRO) return;
+		if(lazy[no] == IDENTITY) return;
 		int m=(l+r)/2, e=no*2, d=e+1;
 
 		seg[no] += (r-l+1) * lazy[no]; /// Range Sum
 
 		if(l != r) lazy[e] += lazy[no], lazy[d] += lazy[no];
-		lazy[no] = NEUTRO;
+		lazy[no] = IDENTITY;
 	}
 
 	T query(int no, int l, int r, int a, int b){
 		unlazy(no, l, r);
-		if(b <  l || r <  a) return NEUTRO;
+		if(b <  l || r <  a) return IDENTITY;
 		if(a <= l && r <= b) return seg[no];
 		int m=(l+r)/2, e=no*2, d=e+1;
 
@@ -70,5 +70,5 @@ Build:  O(N)
 Query:  O(log N) | seg.query(l, r);
 Update: O(log N) | seg.update(l, r, v);
 Unlazy: O(1)
-**Update Join, NEUTRO, Update and Unlazy if needed**
+**Update Join, IDENTITY, Update and Unlazy if needed**
 *******************************************************/


### PR DESCRIPTION
Mesma atualização da Seg sem lazy, exatamente os mesmos motivos, vou copiar a msg pra facilitar....

Troquei de NEUTRO pra IDENTITY pra manter o padrão.

Trocar o default de T NEUTRO = 0; para 	T IDENTITY = T(); faz com que funcione naturalmente para tipos arbitrários pra seg Custom sem dar erro de compilação, com tanto que teu tipo arbitrário tenha um construtor simples (que normalmente já é o neutro mesmo). Fica bem mais fácil. 

Além disso, pra Tipos compostos, quando tu faz inicialização com array, dá um bug bizarro se o assign da seg for com vazio, tem que dar assign de identidade pra funcionar.